### PR TITLE
3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug that would cause `WYSIWYGInput` component to send `onChange` events with stale data while initializing its editor state
+
 ## [3.0.7] - 2021-06-21
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [3.0.8] - 2021-06-23
+
+### Fixed
+
 - Fixed bug that would cause `WYSIWYGInput` component to send `onChange` events with stale data while initializing its editor state
 
 ## [3.0.7] - 2021-06-21

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@perimetre/ui",
-  "version": "3.0.4",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@perimetre/ui",
   "description": "A component library made by @perimetre",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/perimetre/ui.git"

--- a/src/components/WYSIWYGInput/index.tsx
+++ b/src/components/WYSIWYGInput/index.tsx
@@ -160,6 +160,7 @@ export const WYSIWYGInput = forwardRef<WYSIWYGInputRef, WYSIWYGInputProps>(
         defaultDecorators
       )
     );
+    const [isEditorStateInitialized, setIsEditorStateInitialized] = useState(false);
     const editor = useRef<Editor | null>(null);
 
     /**
@@ -173,23 +174,23 @@ export const WYSIWYGInput = forwardRef<WYSIWYGInputRef, WYSIWYGInputProps>(
     };
 
     useEffect(() => {
-      // If the onChange prop is provided
-      if (onChangeProps) {
+      // If the onChange prop is provided and we are finished initializing the component state
+      if (onChangeProps && isEditorStateInitialized) {
         // Notify the change
         onChangeProps(editorState);
       }
       // If the editor state changes
-    }, [editorState, onChangeProps]);
+    }, [editorState, onChangeProps, isEditorStateInitialized]);
 
     useEffect(() => {
-      // If the onChange prop is provided
-      if (onHtmlChangeSlow) {
+      // If the onChange prop is provided and we have initialized the component state
+      if (onHtmlChangeSlow && isEditorStateInitialized) {
         // Ref(HTML part at the end): https://jpuri.github.io/react-draft-wysiwyg/#/docs
         const htmlData = draftToHtml(convertToRaw(editorState.getCurrentContent()));
         onHtmlChangeSlow(DOMPurify.sanitize(htmlData));
       }
       // If the editor state changes
-    }, [editorState, onHtmlChangeSlow]);
+    }, [editorState, onHtmlChangeSlow, isEditorStateInitialized]);
 
     useEffect(() => {
       /**
@@ -208,12 +209,18 @@ export const WYSIWYGInput = forwardRef<WYSIWYGInputRef, WYSIWYGInputProps>(
             defaultDecorators
           )
         );
+
+        // make sure to set component as initialized so that it will start sending onChange events
+        setIsEditorStateInitialized(true);
       };
 
       setEditorState(EditorState.set(editorState, { decorator: defaultDecorators }));
 
       if (defaultHtmlValue) {
         updateFromHtml();
+      } else {
+        // make sure to set component as initialized so that it will start sending onChange events
+        setIsEditorStateInitialized(true);
       }
       // Disable because we only want this to update on the first render
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
- fix: for WYSIWYGInput sending onChange events with stale data during initialization
- build: bumping version: 3.0.8

- [x] Have you made sure your branch is up to date with it's parent branch before creating this PR?
- [x] Are all warnings and errors fixed?
- [x] Have you throughoutfully commented your changes?
- [x] Have you added proper jsdocs comments?
- [x] Have you updated the **CHANGELOG** file?
  - [x] Have all _**breaking changes**_ been properly documented and communicated?
  - [x] Have all _changes_ been properly documented and communicated?
  - [x] Have all _fixed issues_ been properly documented and communicated?
- [x] **Have you raised the `version` in package.json if applicable?**
- [x] Have you randomly paid a compliment to a colleague today?

---

- [x] **Do you agree that by pushing to master(if the case). You'll generate a new package build?**
